### PR TITLE
Refactor clerk auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ node .\server.js
 
 setup:
 docker run -d -p 5672:5672 -p 15672:15672 --name rabbitmq rabbitmq
+
+## Clerk JWT claims
+
+Authentication now relies solely on Clerk session tokens. Configure your JWT template in the Clerk dashboard to include the following claims:
+
+- `internal_user_id`
+- `workspace_id`
+- `role`
+- `permissions` (optional)
+
+These claims allow the backend to authorize requests without additional database lookups.

--- a/middlewares/clerkAuth.js
+++ b/middlewares/clerkAuth.js
@@ -1,131 +1,39 @@
-/*
-// dependencies
-const jose = require('jose'); // npm install jose
-const fetch = require('node-fetch'); // For JWKS retrieval
-
-// -- Clerk config --
-const CLERK_JWKS_URL = 'https://crisp-gnat-74.clerk.accounts.dev/.well-known/jwks.json'; // e.g., https://clerk.yourdomain.com/.well-known/jwks.json
-
-// 1. Cache the JWKS to avoid repeated fetches
-let jwksCache = null;
-let jwksFetchedAt = 0;
-const JWKS_CACHE_TTL = 60 * 60 * 1000; // 1 hour cache
-
-async function getClerkJWKS() {
-    const now = Date.now();
-    if (jwksCache && (now - jwksFetchedAt) < JWKS_CACHE_TTL) return jwksCache;
-    const res = await fetch(CLERK_JWKS_URL);
-    if (!res.ok) throw new Error('Failed to load Clerk JWKS');
-    jwksCache = await res.json();
-    jwksFetchedAt = now;
-    return jwksCache;
-}
-
-// -- Clerk auth --
-// JWKS + JWT verification using token destructuring fron clerk token
-
-async function verifyUserClerkJWT(token) {
-    try {
-        // 2. Load Clerk JWKS for public keys
-        const jwks = await getClerkJWKS();
-
-        // 3. Create JWKS key set
-        const keyStore = jose.createRemoteJWKSet(new URL(CLERK_JWKS_URL));
-
-        // 4. Verify the token; throws if invalid/expired
-        const { payload } = await jose.jwtVerify(token, keyStore);
-
-        // 5. Required claims from custom JWT template
-        const internalUserId = payload.internal_user_id || payload.internalUserId;
-        const workspaceId = payload.workspace_id || payload.workspaceId;
-
-        if (!internalUserId || !workspaceId) {
-            throw new Error("Missing required claims in Clerk JWT");
-        }
-
-        // 6. Shape the result as needed for your reducers/middleware
-        return {
-            id: internalUserId,
-            workspaceId: workspaceId,
-            sub: payload.sub,                 // Clerk User ID (optional)
-            email: payload.email,             // Only if you included it in JWT template
-            role: payload.role,               // Only if in template
-            // ...add other claims as needed
-        };
-
-    } catch (err) {
-        // Handle and log invalid auth
-        throw new Error('Invalid or expired Clerk token: ' + err.message);
-    }
-}
-
-// Pseudo-middleware for Fastify/Express
-async function clerkAuthMiddleware(req, res, next) {
-    try {
-        const auth = req.headers.authorization;
-        if (!auth?.startsWith('Bearer ')) throw new Error('Unauthorized');
-        const token = auth.slice(7); // Remove 'Bearer '
-        const user = await verifyUserClerkJWT(token);
-        req.user = user; // Attach to request for downstream logic
-        next();
-    } catch (err) {
-        res.status(401).json({ error: 'Unauthorized: ' + err.message });
-    }
-}
-
-module.exports = {
-    verifyUserClerkJWT,
-    clerkAuthMiddleware
-}; 
-
-*/
-
-// middlewares/auth.js - maintains the previous res of verifyUser legacy (directly checks clerk token)
 const { verifyToken } = require('@clerk/backend');
-const { createClient } = require('@supabase/supabase-js');
-const errors = require('../errors'); // Your error helpers
-const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
+const errors = require('../errors');
 
+/**
+ * Verify a Clerk session token and return the claims needed for auth.
+ * This middleware relies solely on Clerk and does not query Supabase.
+ */
 const verifyUserToken = async (token) => {
-    if (!token) throw new errors.Unauthorized('No token provided.');
+  if (!token) throw new errors.Unauthorized('No token provided.');
 
-    let decoded;
-    try {
-        const payload = await verifyToken(token);
-        decoded = payload;
-    } catch (err) {
-        throw new errors.Unauthorized('Invalid token.');
-    }
+  let decoded;
+  try {
+    decoded = await verifyToken(token);
+  } catch (err) {
+    throw new errors.Unauthorized('Invalid token.');
+  }
 
-    const clerkUserId = decoded.sub || decoded.clerkUserId; // prefer `sub`
-    const internalUserId = decoded.internal_user_id;
+  const clerkUserId = decoded.sub || decoded.clerkUserId;
+  const internalUserId = decoded.internal_user_id || decoded.internalUserId;
+  const workspaceId = decoded.workspace_id || decoded.workspaceId;
+  const role = decoded.role;
 
-    // Fetch user based on Clerk or internal user ID
-    const { data: user, error: userError } = await supabase
-        .from('users')
-        .select('id, email, fName, lName, defaultWorkspaceId, clientId')
-        .eq('id', internalUserId)
-        .single();
+  if (!internalUserId || !workspaceId || !role) {
+    throw new errors.Unauthorized('Missing required claims.');
+  }
 
-    if (userError || !user) {
-        throw new errors.Unauthorized('User not found.');
-    }
-
-    // Fetch role
-    const { data: permission } = await supabase
-        .from('workspacePermissions')
-        .select('role')
-        .eq('userId', user.id)
-        .eq('workspaceId', user.defaultWorkspaceId)
-        .single();
-
-    return {
-        ...user,
-        role: permission?.role || null,
-        clerkUserId,
-    };
+  return {
+    id: internalUserId,
+    workspaceId,
+    role,
+    clerkUserId,
+    email: decoded.email,
+    permissions: decoded.permissions || null,
+  };
 };
 
 module.exports = {
-    verifyUserToken,
+  verifyUserToken,
 };

--- a/routes/clerkAuthRoutes/index.js
+++ b/routes/clerkAuthRoutes/index.js
@@ -4,7 +4,7 @@ async function activate(app) {
     let handler = new Handler();
     let base_url = '/api/clerk-auth';
 
-    // Clerk login - returns same format as /api/auth/login
+    // Clerk login
     app.route({
         url: base_url + "/login",
         method: 'POST',
@@ -12,7 +12,7 @@ async function activate(app) {
         schema: {
             tags: ['ClerkAuth'],
             summary: 'Login with Clerk',
-            description: 'Login using Clerk session token, returns same format as regular login.',
+            description: 'Validate a Clerk session token and return user claims.',
             body: {
                 type: 'object',
                 required: ['clerkSessionToken'],
@@ -54,7 +54,7 @@ async function activate(app) {
         }
     });
 
-    // Clerk logout
+    // Clerk logout (no-op on backend)
     app.route({
         url: base_url + "/logout",
         method: 'POST',
@@ -62,16 +62,10 @@ async function activate(app) {
         schema: {
             tags: ['ClerkAuth'],
             summary: 'Logout Clerk User',
-            description: 'Logout user and revoke access token.',
+            description: 'Placeholder endpoint for client side logout.',
             body: {
                 type: 'object',
-                required: ['accessToken'],
-                properties: {
-                    accessToken: {
-                        type: 'string',
-                        description: 'Access token to revoke'
-                    }
-                }
+                properties: {}
             }
         },
         handler: async (req, reply) => {
@@ -79,7 +73,7 @@ async function activate(app) {
         }
     });
 
-    // Check token (for middleware compatibility)
+    // Check token (validate Clerk session token)
     app.route({
         url: base_url + "/check-token",
         method: 'POST',
@@ -87,13 +81,13 @@ async function activate(app) {
         schema: {
             tags: ['ClerkAuth'],
             summary: 'Check Token Validity',
-            description: 'Check if access token is valid (for middleware use).',
+            description: 'Check if a Clerk session token is valid.',
             body: {
                 type: 'object',
                 properties: {
                     token: {
                         type: 'string',
-                        description: 'Access token to check'
+                        description: 'Clerk session token to verify'
                     }
                 }
             }

--- a/services/ClerkAuthService.js
+++ b/services/ClerkAuthService.js
@@ -1,207 +1,99 @@
-const { v4: uuidv4 } = require('uuid');
-const { createClient } = require('@supabase/supabase-js');
 const clerkClient = require('../config/clerkClient');
 const BaseService = require('./BaseService');
 const errors = require('../errors');
 
 class ClerkAuthService extends BaseService {
-    constructor() {
-        super();
-        this.supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
+  constructor() {
+    super();
+  }
+
+  /**
+   * Validate the Clerk session token and return user claims.
+   */
+  async loginWithClerk(clerkSessionToken, _userAgent = null, _ip = null) {
+    try {
+      const payload = await clerkClient.verifyToken(clerkSessionToken);
+      if (!payload || !payload.sub) {
+        throw new errors.InvalidCredentials('Invalid Clerk session token');
+      }
+
+      const internalUserId = payload.internal_user_id || payload.internalUserId;
+      const workspaceId = payload.workspace_id || payload.workspaceId;
+      const role = payload.role;
+
+      if (!internalUserId || !workspaceId || !role) {
+        throw new errors.InvalidCredentials('Missing required claims in token');
+      }
+
+      return {
+        id: internalUserId,
+        clerkUserId: payload.sub,
+        workspaceId,
+        role,
+        email: payload.email,
+        permissions: payload.permissions || null,
+        token: clerkSessionToken,
+      };
+    } catch (error) {
+      return this.handleError(error);
     }
+  }
 
-    /**
-     * Login using Clerk session token but return same format as AuthService.login()
-     * This maintains compatibility with existing frontend logic
-     */
-    async loginWithClerk(clerkSessionToken, userAgent = null, ip = null) {
-        try {
-            console.log('🔐 Processing Clerk login...');
+  /**
+   * Fetch user details from Clerk.
+   */
+  async getCurrentClerkUser(clerkSessionToken) {
+    try {
+      const payload = await clerkClient.verifyToken(clerkSessionToken);
+      if (!payload || !payload.sub) {
+        throw new errors.InvalidCredentials('Invalid Clerk session token');
+      }
+      const user = await clerkClient.users.getUser(payload.sub);
 
-            // 1. Verify Clerk session token and get user
-            const clerkUser = await clerkClient.verifyToken(clerkSessionToken);
-
-            if (!clerkUser || !clerkUser.sub) {
-                throw new errors.InvalidCredentials('Invalid Clerk session token');
-            }
-
-            const clerkUserId = clerkUser.sub;
-            console.log('✅ Clerk token verified for user:', clerkUserId);
-
-            // 2. Get our internal user record
-            const { data: user, error: userError } = await this.supabase
-                .from('users')
-                .select('*')
-                .eq('clerkUserId', clerkUserId)
-                .single();
-
-            if (userError || !user) {
-                throw new errors.NotFound('User not found in internal database');
-            }
-
-            if (!user.defaultWorkspaceId) {
-                throw new Error('Workspace not found for user');
-            }
-
-            // 3. Check workspace permissions
-            const { data: permission } = await this.supabase
-                .from('workspacePermissions')
-                .select('*')
-                .eq('userId', user.id)
-                .eq('workspaceId', user.defaultWorkspaceId)
-                .single();
-
-            if (!permission?.access) {
-                throw new Error('Access not allowed to this workspace. Please contact admin.');
-            }
-
-            // 4. Create access token (same format as original AuthService)
-            const accessToken = {
-                token: uuidv4(),
-                expiry: Date.now() + (1 * 60 * 60 * 1000), // 1 hour from now
-                issuedAt: new Date(),
-                userAgent,
-                ip
-            };
-
-            // 5. Store access token in database
-            await this.supabase.from('userAccessTokens').insert({
-                user_id: user.id,
-                token: accessToken.token,
-                issuedAt: accessToken.issuedAt,
-                expiry: new Date(accessToken.expiry),
-                userAgent: accessToken.userAgent,
-                ip: accessToken.ip
-            });
-
-            // 6. Return EXACT same format as AuthService.login()
-            return {
-                id: user.id,
-                accessToken,
-                roleIds: user.roleIds,
-                firstName: user.fName,  // Note: mapping fName to firstName
-                lastName: user.lName,   // Note: mapping lName to lastName
-                defaultWorkspaceId: user.defaultWorkspaceId
-            };
-
-        } catch (error) {
-            console.error('❌ Clerk login error:', error);
-            return this.handleError(error);
-        }
+      return {
+        success: true,
+        data: {
+          clerkUser: user,
+        },
+      };
+    } catch (error) {
+      return this.handleError(error);
     }
+  }
 
-    /**
-     * Get Clerk user info and sync with our records
-     * Useful for getting current user data
-     */
-    async getCurrentClerkUser(clerkSessionToken) {
-        try {
-            const clerkUser = await clerkClient.verifyToken(clerkSessionToken);
+  /**
+   * Since we do not store sessions, logout is a no-op.
+   */
+  async logoutClerkUser(_token) {
+    return { message: 'Logged out successfully' };
+  }
 
-            if (!clerkUser || !clerkUser.sub) {
-                throw new errors.InvalidCredentials('Invalid Clerk session token');
-            }
+  /**
+   * Validate a token and return the decoded claims.
+   */
+  async checkClerkToken(token) {
+    try {
+      const payload = await clerkClient.verifyToken(token);
+      const internalUserId = payload.internal_user_id || payload.internalUserId;
+      const workspaceId = payload.workspace_id || payload.workspaceId;
+      const role = payload.role;
 
-            // Get full Clerk user data
-            const fullClerkUser = await clerkClient.users.getUser(clerkUser.sub);
+      if (!internalUserId || !workspaceId || !role) {
+        throw new errors.Unauthorized();
+      }
 
-            // Get our internal user data
-            const { data: internalUser } = await this.supabase
-                .from('users')
-                .select('*')
-                .eq('clerkUserId', clerkUser.sub)
-                .single();
-
-            return {
-                success: true,
-                data: {
-                    clerkUser: {
-                        id: fullClerkUser.id,
-                        email: fullClerkUser.emailAddresses[0]?.emailAddress,
-                        firstName: fullClerkUser.firstName,
-                        lastName: fullClerkUser.lastName,
-                        publicMetadata: fullClerkUser.publicMetadata
-                    },
-                    internalUser: internalUser
-                }
-            };
-
-        } catch (error) {
-            console.error('Error getting current Clerk user:', error);
-            return this.handleError(error);
-        }
+      return {
+        id: internalUserId,
+        workspaceId,
+        role,
+        clerkUserId: payload.sub,
+        email: payload.email,
+        permissions: payload.permissions || null,
+      };
+    } catch (error) {
+      return this.handleError(error);
     }
-
-    /**
-     * Logout - revoke access token
-     * Same behavior as original AuthService but for Clerk users
-     */
-    async logoutClerkUser(accessToken) {
-        try {
-            // Remove the access token from database
-            await this.supabase
-                .from('userAccessTokens')
-                .delete()
-                .eq('token', accessToken);
-
-            return { message: "Logged out successfully" };
-
-        } catch (error) {
-            console.error('Error during Clerk logout:', error);
-            return this.handleError(error);
-        }
-    }
-
-    /**
-     * Check token validity (same as AuthService.checkToken but for Clerk users)
-     */
-    async checkClerkToken(token) {
-        try {
-            // Fetch user based on the token
-            let { data: session, error: sessionError } = await this.supabase
-                .from('userAccessTokens')
-                .select('user_id, expiry')
-                .eq('token', token)
-                .single();
-
-            if (sessionError || !session) {
-                return Promise.reject(new errors.Unauthorized());
-            }
-
-            // Check if session expired
-            if (session.expiry < Date.now()) {
-                return Promise.reject(new errors.Unauthorized("Session expired, please login again."));
-            }
-
-            // Fetch full user details
-            let { data: user, error: userError } = await this.supabase
-                .from('users')
-                .select('id, email, fName, lName, name, defaultWorkspaceId, clientId, clerkUserId')
-                .eq('id', session.user_id)
-                .single();
-
-            if (userError || !user) {
-                return Promise.reject(new errors.Unauthorized());
-            }
-
-            // Fetch user role from workspacePermissions
-            let { data: permission, error: permissionError } = await this.supabase
-                .from('workspacePermissions')
-                .select('role')
-                .eq('userId', user.id)
-                .eq('workspaceId', user.defaultWorkspaceId)
-                .single();
-
-            return {
-                ...user,
-                role: permission?.role || null,
-            };
-
-        } catch (error) {
-            console.error('Error checking Clerk token:', error);
-            return this.handleError(error);
-        }
-    }
+  }
 }
 
-module.exports = ClerkAuthService; 
+module.exports = ClerkAuthService;


### PR DESCRIPTION
## Summary
- stop querying Supabase from clerkAuth middleware
- simplify ClerkAuthService to use Clerk claims only
- adjust Clerk auth routes and docs
- document Clerk JWT claims

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:4000)*

------
https://chatgpt.com/codex/tasks/task_b_6887ca206a288328874995ef0dd49ba4